### PR TITLE
Add handling for HTTP 204: No Content

### DIFF
--- a/fermata.js
+++ b/fermata.js
@@ -391,7 +391,7 @@ fermata.registerPlugin('autoConvert', function (transport, defaultType) {
                 resType = response && response.headers['Content-Type'],
                 decoder = (TYPES[accType] || TYPES[resType] || [])[1];
             if (decoder) {
-                if (response.status.toFixed() === '204') {
+                if (response && response.status && response.status.toFixed() === '204') {
                     response = {};
                 } else {
                     try {


### PR DESCRIPTION
if there's no content, we shouldn't end up with a parsing error.
