### PR TITLE
added bower.json for Bower registration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "fermata",
+  "main": "fermata.js",
+  "version": "0.10.1",
+  "homepage": "https://github.com/natevw/fermata",
+  "authors": [
+    "Nathan Vander Wilt <nate@calftrail.com>"
+  ],
+  "description": "Succinct native REST client, for client-side web apps and node.js. Turns URLs into magic JavaScript objects. Supports JSON, CouchDB, OAuth 1.0a, form uploads and more!",
+  "keywords": [
+    "REST",
+    "AJAX",
+    "nodejs",
+    "magic"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
The dependencies in bower.json are different from the package.json file for node, it refers to any bower dependencies, which I couldn't find in the repo.

I also jacked your email address from your website for the author section, feel free to change that as necessary. 

No idea what keywords you wanted, so I just kinda pulled some outta my hat.

Once there's a bower.json file in the repo, I can register it for you with the bower registry, or you can from the instruction in that link I put in the issue.
