### PR TITLE
Work in browser environments that also have `exports`

### DIFF
--- a/fermata.js
+++ b/fermata.js
@@ -267,16 +267,18 @@ fermata._typeof2 = function (o) {
     return (Array.isArray(o)) ? 'array' : typeof(o);
 };
 
+if (typeof exports !== 'undefined') {
+    fermata._useExports = true;
+    exports.registerPlugin = fermata.registerPlugin;
+    exports.plugins = fermata.plugins;
+}
 
 if (typeof window === 'undefined') {
-    fermata._useExports = true;
     fermata._transport = fermata._nodeTransport;
     fermata.registerPlugin('oauth', require("./oauth").init(fermata));
     if (!Proxy) {
         fermata._nodeProxy = require('node-proxy');
     }
-    exports.registerPlugin = fermata.registerPlugin;
-    exports.plugins = fermata.plugins;
 } else {
     fermata._transport = fermata._xhrTransport;
 }


### PR DESCRIPTION
With libraries such as [Mr](https://github.com/montagejs/mr) it's possible to be in the browser, but also need to use `exports`. This simple patch enables this without breaking node.