### PR TITLE
Add oauth_version parameter to OAuth header.

### DIFF
--- a/oauth.js
+++ b/oauth.js
@@ -59,7 +59,10 @@ oauth.signatureBaseString = function (req, auth) {
 oauth.authorizeHMAC = function (request, cred) {
     var crypto = require('crypto');     // only node.js supported (browser leaks client credentials)
     
-    var auth = {signature_method:"HMAC-SHA1"};
+    var auth = {
+        version: "1.0",
+        signature_method: "HMAC-SHA1"
+    };
     auth.consumer_key = cred.client;
     if (cred.token) {
         auth.token = cred.token;


### PR DESCRIPTION
According to [RFC 5949 &sect;3.1](http://tools.ietf.org/html/rfc5849#section-3.1) the `oauth_version` parameter is optional, but the [bitbucket.org API](https://confluence.atlassian.com/display/BITBUCKET/OAuth+on+Bitbucket) has been observed to require it.
