### PR TITLE
Allow sending xhr properties through request object in plugin

### DIFF
--- a/fermata.js
+++ b/fermata.js
@@ -188,10 +188,18 @@ fermata._nodeTransport = function (request, callback) {
     return req;
 };
 
+fermata._isObject = function(value) {
+    return Object.prototype.toString.call(value) === '[object Object]'
+};
+
 fermata._xhrTransport = function (request, callback) {
     var xhr = new XMLHttpRequest(),
         url = fermata._stringForURL(request);
-    
+    var props = request.properties;
+    props = fermata._isObject(props) ? props || {};
+    for(var i in props) {
+        xhr[i] = props[i];
+    }
     xhr.open(request.method, url, true);
     Object.keys(request.headers).forEach(function (k) {
         xhr.setRequestHeader(k, request.headers[k]);


### PR DESCRIPTION
Adding properties like `withCredentials: true` is very common in some applications. Currently there is no way to pass properties to XHR object through config. This commit let user to pass properties like below

`req.properties = { withCredentials: true }` inside plugin wrapper.

And thanks a lot for such a library. This is one of the awesome and simple libraries.
